### PR TITLE
Enable hot reload for conda-store server

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/__main__.py
+++ b/conda-store-server/conda_store_server/_internal/server/__main__.py
@@ -15,16 +15,3 @@ main = CondaStoreServer.launch_instance
 
 if __name__ == "__main__":
     server = main()
-    uvicorn.run(
-        "conda_store_server._internal.server.app:CondaStoreServer.create_webserver",
-        host=server.address,
-        port=server.port,
-        workers=1,
-        proxy_headers=server.behind_proxy,
-        forwarded_allow_ips=("*" if server.behind_proxy else None),
-        reload=server.reload,
-        reload_dirs=(
-            [os.path.dirname(conda_store_server.__file__)] if server.reload else []
-        ),
-        factory=True,
-    )


### PR DESCRIPTION
This moves the fast-api initialization from the CondaStoreServer "start" function to the create_webserver factory. Now, the "create_webserver" factory (runs when reload is enabled + one of the watched file paths changes) the following actions will happen:
* the conda server application config get re-read + initialized
* the fast api app gets reloaded

refs:
https://github.com/ipython/traitlets/blob/main/examples/myapp.py
https://traitlets.readthedocs.io/en/stable/config-api.html#traitlets.config.Application.launch_instance

