### PR TITLE
Move running db migrations out of conda-store app init loop

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/__main__.py
+++ b/conda-store-server/conda_store_server/_internal/server/__main__.py
@@ -2,11 +2,10 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-
 from conda_store_server._internal.server.app import CondaStoreServer
 
 
 main = CondaStoreServer.launch_instance
 
 if __name__ == "__main__":
-    server = main()
+    main()

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -207,9 +207,6 @@ class CondaStoreServer(Application):
             f"Running conda-store with store directory: {self.conda_store.store_directory}"
         )
 
-        if self.conda_store.upgrade_db:
-            dbutil.upgrade(self.conda_store.database_url)
-
         self.authentication = self.authentication_class(
             parent=self,
             log=self.log,
@@ -218,6 +215,11 @@ class CondaStoreServer(Application):
 
         # ensure checks on redis_url
         self.conda_store.redis_url
+
+    def run_db_migrations(self):
+        if self.conda_store.upgrade_db:
+            dbutil.upgrade(self.conda_store.database_url)
+
 
     def init_fastapi_app(self):
         def trim_slash(url):
@@ -390,6 +392,8 @@ class CondaStoreServer(Application):
 
     def start(self):
         """Start the CondaStoreServer application, and run a FastAPI-based webserver."""
+        self.run_db_migrations()
+
         with self.conda_store.session_factory() as db:
             self.conda_store.ensure_settings(db)
             self.conda_store.ensure_namespace(db)


### PR DESCRIPTION
With this change, when a hot reload happens a db migration does not run 