### PR TITLE
Ensure lockfile is preserved when dumping model

### DIFF
--- a/conda-store-server/conda_store_server/_internal/schema.py
+++ b/conda-store-server/conda_store_server/_internal/schema.py
@@ -445,7 +445,7 @@ class LockfileSpecification(BaseModel):
 
         return super().parse_obj(specification)
 
-    def dict(self):
+    def model_dump(self):
         res = super().model_dump()
         # The dict_for_output method includes the version field into the output
         # and excludes unset fields. Without the version field present,

--- a/conda-store-server/tests/_internal/action/test_actions.py
+++ b/conda-store-server/tests/_internal/action/test_actions.py
@@ -174,6 +174,13 @@ def test_solve_lockfile_multiple_platforms(conda_store, specification, request):
     assert len(context.result["package"]) != 0
 
 
+def test_save_lockfile(simple_lockfile_specification):
+        """Ensure lockfile is saved in conda-lock `output` format"""
+        context = action.action_save_lockfile(
+            specification=simple_lockfile_specification
+        )
+        assert context.result == simple_lockfile_specification.lockfile.dict_for_output()
+
 @pytest.mark.parametrize(
     "specification_name",
     [

--- a/conda-store-server/tests/_internal/action/test_actions.py
+++ b/conda-store-server/tests/_internal/action/test_actions.py
@@ -175,11 +175,10 @@ def test_solve_lockfile_multiple_platforms(conda_store, specification, request):
 
 
 def test_save_lockfile(simple_lockfile_specification):
-        """Ensure lockfile is saved in conda-lock `output` format"""
-        context = action.action_save_lockfile(
-            specification=simple_lockfile_specification
-        )
-        assert context.result == simple_lockfile_specification.lockfile.dict_for_output()
+    """Ensure lockfile is saved in conda-lock `output` format"""
+    context = action.action_save_lockfile(specification=simple_lockfile_specification)
+    assert context.result == simple_lockfile_specification.lockfile.dict_for_output()
+
 
 @pytest.mark.parametrize(
     "specification_name",

--- a/conda-store-server/tests/_internal/test_schema.py
+++ b/conda-store-server/tests/_internal/test_schema.py
@@ -1,0 +1,77 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+import yaml
+import pytest
+
+from conda_store_server._internal import schema
+
+
+@pytest.fixture
+def test_lockfile():
+    return {
+        "version": 1,
+        "metadata": {
+            "content_hash": {
+                "linux-64": "5514f6769db31a2037c24116f89239737c66d009b2d0c71e2872339c3cf1a8f6"
+            },
+            "channels": [
+                {
+                    "url": "conda-forge",
+                    "used_env_vars": []
+                }
+            ],
+            "platforms": [
+                "linux-64"
+            ],
+            "sources": [
+                "environment.yaml"
+            ]
+        },
+        "package": [
+            {
+                "name": "_libgcc_mutex",
+                "version": "0.1",
+                "manager": "conda",
+                "platform": "linux-64",
+                "dependencies": {},
+                "url": "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2",
+                "hash": {
+                    "md5": "d7c89558ba9fa0495403155b64376d81",
+                    "sha256": "fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726"
+                },
+                "category": "main",
+                "optional": False
+            },
+            {
+                "name": "_openmp_mutex",
+                "version": "4.5",
+                "manager": "conda",
+                "platform": "linux-64",
+                "dependencies": {
+                    "_libgcc_mutex": "0.1",
+                    "libgomp": ">=7.5.0"
+                },
+                "url": "https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2",
+                "hash": {
+                    "md5": "73aaf86a425cc6e73fcf236a5a46396d",
+                    "sha256": "fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22"
+                },
+                "category": "main",
+                "optional": False
+            },
+        ]
+    }
+
+
+def test_parse_lockfile_obj(test_lockfile):
+    lockfile_spec = {
+        "name": "test",
+        "description": "test",
+        # use a copy of the lockfile so it's not mutated and we can compare
+        # against the original dict
+        "lockfile": test_lockfile.copy()
+    }
+    specification = schema.LockfileSpecification.parse_obj(lockfile_spec)
+    assert specification.dict()["lockfile"] == test_lockfile

--- a/conda-store-server/tests/_internal/test_schema.py
+++ b/conda-store-server/tests/_internal/test_schema.py
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-import yaml
 import pytest
 
 from conda_store_server._internal import schema

--- a/conda-store-server/tests/_internal/test_schema.py
+++ b/conda-store-server/tests/_internal/test_schema.py
@@ -15,18 +15,9 @@ def test_lockfile():
             "content_hash": {
                 "linux-64": "5514f6769db31a2037c24116f89239737c66d009b2d0c71e2872339c3cf1a8f6"
             },
-            "channels": [
-                {
-                    "url": "conda-forge",
-                    "used_env_vars": []
-                }
-            ],
-            "platforms": [
-                "linux-64"
-            ],
-            "sources": [
-                "environment.yaml"
-            ]
+            "channels": [{"url": "conda-forge", "used_env_vars": []}],
+            "platforms": ["linux-64"],
+            "sources": ["environment.yaml"],
         },
         "package": [
             {
@@ -38,29 +29,26 @@ def test_lockfile():
                 "url": "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2",
                 "hash": {
                     "md5": "d7c89558ba9fa0495403155b64376d81",
-                    "sha256": "fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726"
+                    "sha256": "fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726",
                 },
                 "category": "main",
-                "optional": False
+                "optional": False,
             },
             {
                 "name": "_openmp_mutex",
                 "version": "4.5",
                 "manager": "conda",
                 "platform": "linux-64",
-                "dependencies": {
-                    "_libgcc_mutex": "0.1",
-                    "libgomp": ">=7.5.0"
-                },
+                "dependencies": {"_libgcc_mutex": "0.1", "libgomp": ">=7.5.0"},
                 "url": "https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2",
                 "hash": {
                     "md5": "73aaf86a425cc6e73fcf236a5a46396d",
-                    "sha256": "fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22"
+                    "sha256": "fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22",
                 },
                 "category": "main",
-                "optional": False
+                "optional": False,
             },
-        ]
+        ],
     }
 
 
@@ -70,7 +58,7 @@ def test_parse_lockfile_obj(test_lockfile):
         "description": "test",
         # use a copy of the lockfile so it's not mutated and we can compare
         # against the original dict
-        "lockfile": test_lockfile.copy()
+        "lockfile": test_lockfile.copy(),
     }
     specification = schema.LockfileSpecification.parse_obj(lockfile_spec)
     assert specification.dict()["lockfile"] == test_lockfile


### PR DESCRIPTION
fixes  https://github.com/conda-incubator/conda-store/issues/986 
related to  https://github.com/conda-incubator/conda-store/pull/985


## Description

The issue described in https://github.com/conda-incubator/conda-store/issues/986 is (in part) caused by https://github.com/conda-incubator/conda-store/blob/main/conda-store-server/conda_store_server/_internal/server/views/api.py#L883-L890 where the lockfile spec is loaded into the `LockfileSpecification` model. When this happens, some of the fields from the lockfile disappear. 

This happens here because in updating pydantic the way the model was getting dumped also was updated. Moving from calling the `dict` function to the `model_dump` function. For example in https://github.com/conda-incubator/conda-store/pull/985/files#diff-91666c161b2c4e479323a0d582f7ab9198bcc1523739281e191fb433fbb4c69bR85. Using`model_dump` directly skips using conda-lock's  [`dict_for_output`](https://github.com/conda/conda-lock/blob/main/conda_lock/lockfile/v1/models.py#L305) function, which is required for properly dumping the model. 

By ensuring that the conda lock `dict_for_output` is used to dump the `LockfileSpecification` model, the issue described in  https://github.com/conda-incubator/conda-store/issues/986  is resolved


## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

